### PR TITLE
Add initial Go CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # os-bot
+
+A starting CLI application written in Go.
+
+## Building
+
+```bash
+go build
+```
+
+## Running
+
+```
+./os-bot -interactive
+```
+
+In interactive mode, type `help` to see available commands.
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/os-bot
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+    "bufio"
+    "flag"
+    "fmt"
+    "os"
+)
+
+const version = "0.1.0"
+
+func main() {
+    interactive := flag.Bool("interactive", false, "run in interactive mode")
+    flag.Parse()
+
+    if *interactive {
+        runInteractive()
+        return
+    }
+
+    if flag.NArg() == 0 {
+        fmt.Println("Usage: os-bot [flags] <command>")
+        fmt.Println("Commands: hello, version")
+        return
+    }
+
+    handleCommand(flag.Arg(0))
+}
+
+func runInteractive() {
+    scanner := bufio.NewScanner(os.Stdin)
+    fmt.Println("Interactive mode. Type 'help' for commands. Type 'quit' to exit.")
+    for {
+        fmt.Print("> ")
+        if !scanner.Scan() {
+            break
+        }
+        text := scanner.Text()
+        if text == "quit" || text == "exit" {
+            return
+        }
+        if text == "help" {
+            fmt.Println("Commands: hello, version, help, quit")
+            continue
+        }
+        handleCommand(text)
+    }
+}
+
+func handleCommand(cmd string) {
+    switch cmd {
+    case "hello":
+        fmt.Println("Hello, world!")
+    case "version":
+        fmt.Printf("os-bot version %s\n", version)
+    default:
+        fmt.Printf("unknown command: %s\n", cmd)
+    }
+}
+


### PR DESCRIPTION
## Summary
- set up go module
- implement `main.go` with interactive CLI
- update `README` with build & run instructions

## Testing
- `go build`

------
https://chatgpt.com/codex/tasks/task_e_68677bbba48c83329a6b0dfa2509abeb