### PR TITLE
Add build and lint CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - run: go build ./cmd/os-bot
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55
+          args: --timeout=5m


### PR DESCRIPTION
## Summary
- set up a GitHub Actions workflow to build the CLI and run golangci-lint

## Testing
- `go build ./cmd/os-bot`


------
https://chatgpt.com/codex/tasks/task_e_68677f7384688332892e31f13e416e25