### PR TITLE
Update CI lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,5 @@ jobs:
       - run: go build ./cmd/os-bot
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55
+          version: v1.58
           args: --timeout=5m


### PR DESCRIPTION
## Summary
- bump golangci-lint action to v1.58

`go build` executed successfully.


------
https://chatgpt.com/codex/tasks/task_e_68688aee0294833282709e5cdc464336