### PR TITLE
Add Makefile for ollama install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+install-ollama:
+	curl -fsSL https://ollama.ai/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ You can also run a single command directly:
 ./os-bot <command>
 ```
 
+
+## Installing Ollama
+
+To install the [Ollama](https://ollama.ai) CLI, run:
+
+```bash
+make install-ollama
+```


### PR DESCRIPTION
## Summary
- add a Makefile with a target to install the Ollama CLI
- document the new Makefile target in the README
- `go build` ran successfully

## Testing
- `gofmt -w cmd/os-bot/main.go internal/cli/cli.go`
- `go build ./cmd/os-bot`


------
https://chatgpt.com/codex/tasks/task_e_68688b1d1e6483329057556977f8cfd9